### PR TITLE
fix empty dendrogram steps bug

### DIFF
--- a/go-kodama/kodama.go
+++ b/go-kodama/kodama.go
@@ -108,6 +108,14 @@ func (dend *Dendrogram) Observations() int {
 // Steps returns a slice of steps that make up the given dendrogram.
 func (dend *Dendrogram) Steps() []Step {
 	len := dend.Len()
+	if len == 0 {
+		// Why do we special case the empty dendrogram? Well, it turns
+		// out that for an empty dendrogram, the pointer returned by
+		// Rust doesn't actually point to valid memory, and Go does not
+		// like this one bit. So avoid asking for the steps when we
+		// know they are empty.
+		return []Step{}
+	}
 	csteps := C.kodama_dendrogram_steps(dend.p)
 	gosteps := (*[math.MaxInt32]C.kodama_step)(unsafe.Pointer(csteps))[:len:len]
 

--- a/go-kodama/kodama_test.go
+++ b/go-kodama/kodama_test.go
@@ -88,6 +88,19 @@ func TestLinkage64Empty(t *testing.T) {
 	}
 }
 
+func TestLinkage64EmptySteps(t *testing.T) {
+	dis := []float64{}
+	dend := Linkage64(dis, 0, MethodAverage)
+	if steps := dend.Steps(); len(steps) != 0 {
+		t.Fatalf("expected zero steps, but got %d steps\n", len(steps))
+	}
+
+	dend = Linkage64(dis, 1, MethodAverage)
+	if steps := dend.Steps(); len(steps) != 0 {
+		t.Fatalf("expected zero steps, but got %d steps\n", len(steps))
+	}
+}
+
 func TestLinkage32Empty(t *testing.T) {
 	// nil slice
 	var dis []float32
@@ -105,6 +118,19 @@ func TestLinkage32Empty(t *testing.T) {
 	// (1 observation has an empty dissimilarity matrix)
 	if dend := Linkage32(dis, 1, MethodAverage); dend.Len() != 0 {
 		t.Fatalf("expected empty dendrogram, but got one of length %d\n", dend.Len())
+	}
+}
+
+func TestLinkage32EmptySteps(t *testing.T) {
+	dis := []float32{}
+	dend := Linkage32(dis, 0, MethodAverage)
+	if steps := dend.Steps(); len(steps) != 0 {
+		t.Fatalf("expected zero steps, but got %d steps\n", len(steps))
+	}
+
+	dend = Linkage32(dis, 1, MethodAverage)
+	if steps := dend.Steps(); len(steps) != 0 {
+		t.Fatalf("expected zero steps, but got %d steps\n", len(steps))
 	}
 }
 

--- a/kodama-capi/src/lib.rs
+++ b/kodama-capi/src/lib.rs
@@ -10,18 +10,20 @@ use libc::{c_double, c_float, size_t};
 mod macros;
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub enum kodama_method {
     Single, Complete, Average, Weighted, Ward, Centroid, Median,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct kodama_dendrogram {
     steps: Vec<kodama_step>,
     observations: size_t,
 }
 
 #[repr(C)]
+#[derive(Debug)]
 pub struct kodama_step {
     pub cluster1: size_t,
     pub cluster2: size_t,


### PR DESCRIPTION
In a recent commit, we fixed the linkage routines to handle the case of
an empty matrix gracefully. Unfortunately, this seems to have uncovered
another bug. When asking for the steps from an empty dendrogram, the
Rust FFI code does something like this:

    creating an empty dendrogram:

      let steps = vec![];
      for i in 0..num_steps { // num_steps == 0 here
        steps.push(build_step(...));
      }
      dendrogram{steps: steps}

    asking for the steps:

      dendrogram.steps.as_ptr()

It turns out that when Rust creates a `Vec` that has zero capacity, it
specifically does *not* allocate. (This is a very desirable quality,
since it makes creating empty `Vec`s very very cheap.) However, since
the `Vec` doesn't allocate but still provides routines for accessing its
inner raw pointer (e.g., `as_ptr()` above), it must still be able to
provide a non-null pointer. The `Vec` implementation achieves this by
using a pointer value that is known to never point to valid memory.

Go does *not* like this, which makes sense in a way, because it has a
garbage collector and garbage collectors like to do funny things with
pointers. The end result here is that attempting to cast the pointer
returned by Rust to an array on which we can index causes the compiler
to generate code that attempts to dereference the pointer (that we know
is invalid). This in turn causes a nil-dereference panic.

A simple way to fix this is to replace this

    let steps = vec![];

with this

    let steps = Vec::with_capacity(1);

This crates a `Vec` with zero elements but a capacity of `1`, which
forces an allocation, and therefore in turn results in producing a
pointer to valid memory. This makes Go happy.

Alternatively, we can detect this case from the Go code (the dendrogram
is empty) and just return a slice. We choose to do that in this commit,
but for no particularly strong reason other than the fact that it seems
weird to create a non-empty allocation on the Rust side.
