### PR TITLE
Re-enable `num-traits` under an optional feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
     - run: cargo build --verbose
     - run: cargo doc --verbose
     - run: cargo test --verbose
+    - run: cargo test --verbose --features float-trait
     - run: cargo build --verbose --manifest-path kodama-capi/Cargo.toml
     - run: cargo build --verbose --manifest-path kodama-bin/Cargo.toml
     - if: matrix.rust == 'nightly'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ members = ["kodama-bin", "kodama-capi"]
 [lib]
 name = "kodama"
 
+[dependencies.num-traits]
+# For writing generic floating point code.
+version = "0.2.12"
+optional = true
+
 [dev-dependencies]
 # For reading benchmark data.
 byteorder = "1.4.3"
@@ -29,6 +34,10 @@ rand = "0.8.4"
 lazy_static = "1.4.0"
 # For property based testing.
 quickcheck = { version = "1.0.3", default-features = false }
+
+[features]
+default = []
+float-trait = ["num-traits"]
 
 [profile.release]
 debug = true

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,8 +1,9 @@
 use std::mem;
 
+use crate::Float;
+
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;
-use crate::float::Float;
 use crate::method;
 use crate::{LinkageState, MethodChain};
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,7 +1,6 @@
 use std::mem;
 
 use crate::Float;
-
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;
 use crate::method;

--- a/src/dendrogram.rs
+++ b/src/dendrogram.rs
@@ -1,7 +1,7 @@
 use std::mem;
 use std::ops;
 
-use crate::float::Float;
+use crate::Float;
 
 /// A step-wise dendrogram that represents a hierarchical clustering as a
 /// binary tree.

--- a/src/float.rs
+++ b/src/float.rs
@@ -6,6 +6,54 @@ mod private {
     pub trait Sealed {}
     impl Sealed for f32 {}
     impl Sealed for f64 {}
+
+    /// The `SealedCast` trait stops crates other than kodama from implementing 
+    /// any traits that use it.
+    pub trait SealedCast {}
+    impl SealedCast for f32 {}
+    impl SealedCast for f64 {}
+    impl SealedCast for usize {}
+}
+
+/// A trait for numbers that can be converted to a float primitive.
+/// 
+/// This is a simplified copy of the homonymous trait from the `num-traits`,
+/// copied here to offer just the features required by `kodama`.
+pub trait ToPrimitive:
+    self::private::SealedCast
+{
+    fn to_f32(&self) -> Option<f32>;
+    fn to_f64(&self) -> Option<f64>;
+}
+
+impl ToPrimitive for f32 {
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self)
+    }
+
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self as f64)
+    }
+}
+
+impl ToPrimitive for f64 {
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self as f32)
+    }
+
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self)
+    }
+}
+
+impl ToPrimitive for usize {
+    fn to_f32(&self) -> Option<f32> {
+        Some(*self as f32)
+    }
+
+    fn to_f64(&self) -> Option<f64> {
+        Some(*self as f64)
+    }
 }
 
 /// A trait for writing generic code over floating point numbers.
@@ -26,13 +74,8 @@ pub trait Float:
     + Div<Self, Output = Self>
     + Mul<Self, Output = Self>
 {
-    /// Converts a `usize` to a float.
-    fn from_usize(v: usize) -> Self;
     /// Converts any floating type to this one.
-    fn from_float<F: Float>(v: F) -> Self;
-    /// Converts this floating type to a `f64`.
-    fn to_f64(self) -> f64;
-
+    fn from<T: ToPrimitive>(v: T) -> Option<Self>;
     /// Returns the representation of "infinity" for this float type.
     fn infinity() -> Self;
     /// Returns the maximum value for this float type.
@@ -44,16 +87,8 @@ pub trait Float:
 }
 
 impl Float for f32 {
-    fn from_usize(v: usize) -> f32 {
-        v as f32
-    }
-
-    fn from_float<F: Float>(v: F) -> f32 {
-        v.to_f64() as f32
-    }
-
-    fn to_f64(self) -> f64 {
-        self as f64
+    fn from<T: ToPrimitive>(v: T) -> Option<f32> {
+        v.to_f32()
     }
 
     fn infinity() -> f32 {
@@ -74,16 +109,8 @@ impl Float for f32 {
 }
 
 impl Float for f64 {
-    fn from_usize(v: usize) -> f64 {
-        v as f64
-    }
-
-    fn from_float<F: Float>(v: F) -> f64 {
+    fn from<T: ToPrimitive>(v: T) -> Option<f64> {
         v.to_f64()
-    }
-
-    fn to_f64(self) -> f64 {
-        self
     }
 
     fn infinity() -> f64 {

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,6 +1,7 @@
+use crate::Float;
+
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;
-use crate::float::Float;
 use crate::method;
 use crate::{LinkageState, Method};
 

--- a/src/generic.rs
+++ b/src/generic.rs
@@ -1,5 +1,4 @@
 use crate::Float;
-
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;
 use crate::method;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,11 @@ pub use crate::generic::{generic, generic_with};
 pub use crate::primitive::{primitive, primitive_with};
 pub use crate::spanning::{mst, mst_with};
 
+#[cfg(not(feature = "float-trait"))]
+pub use crate::float::Float;
+#[cfg(feature = "float-trait")]
+pub use num_traits::Float;
+
 use crate::active::Active;
 use crate::queue::LinkageHeap;
 use crate::union::LinkageUnionFind;
@@ -250,6 +255,7 @@ mod active;
 mod chain;
 mod condensed;
 mod dendrogram;
+#[cfg(not(feature = "float-trait"))]
 mod float;
 mod generic;
 mod method;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,6 @@ use std::str::FromStr;
 
 pub use crate::chain::{nnchain, nnchain_with};
 pub use crate::dendrogram::{Dendrogram, Step};
-pub use crate::float::Float;
 pub use crate::generic::{generic, generic_with};
 pub use crate::primitive::{primitive, primitive_with};
 pub use crate::spanning::{mst, mst_with};

--- a/src/method.rs
+++ b/src/method.rs
@@ -16,14 +16,14 @@ pub fn complete<T: Float>(a: T, b: &mut T) {
 
 #[inline]
 pub fn average<T: Float>(a: T, b: &mut T, size_a: usize, size_b: usize) {
-    let size_a = T::from_usize(size_a);
-    let size_b = T::from_usize(size_b);
+    let size_a = T::from(size_a).unwrap();
+    let size_b = T::from(size_b).unwrap();
     *b = (size_a * a + size_b * *b) / (size_a + size_b);
 }
 
 #[inline]
 pub fn weighted<T: Float>(a: T, b: &mut T) {
-    *b = T::from_float(0.5) * (a + *b);
+    *b = T::from(0.5).unwrap() * (a + *b);
 }
 
 #[inline]
@@ -35,9 +35,9 @@ pub fn ward<T: Float>(
     size_b: usize,
     size_x: usize,
 ) {
-    let size_a = T::from_usize(size_a);
-    let size_b = T::from_usize(size_b);
-    let size_x = T::from_usize(size_x);
+    let size_a = T::from(size_a).unwrap();
+    let size_b = T::from(size_b).unwrap();
+    let size_x = T::from(size_x).unwrap();
 
     let numerator = ((size_x + size_a) * a) + ((size_x + size_b) * *b)
         - (size_x * merged_dist);
@@ -53,8 +53,8 @@ pub fn centroid<T: Float>(
     size_a: usize,
     size_b: usize,
 ) {
-    let size_a = T::from_usize(size_a);
-    let size_b = T::from_usize(size_b);
+    let size_a = T::from(size_a).unwrap();
+    let size_b = T::from(size_b).unwrap();
     let size_ab = size_a + size_b;
 
     *b = (((size_a * a) + (size_b * *b)) / size_ab)
@@ -63,8 +63,8 @@ pub fn centroid<T: Float>(
 
 #[inline]
 pub fn median<T: Float>(a: T, b: &mut T, merged_dist: T) {
-    let half = T::from_float(0.5);
-    let quarter = T::from_float(0.25);
+    let half = T::from(0.5).unwrap();
+    let quarter = T::from(0.25).unwrap();
 
     *b = (half * (a + *b)) - (merged_dist * quarter);
 }

--- a/src/method.rs
+++ b/src/method.rs
@@ -1,4 +1,4 @@
-use crate::float::Float;
+use crate::Float;
 
 #[inline]
 pub fn single<T: Float>(a: T, b: &mut T) {

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -1,9 +1,7 @@
 use crate::Float;
-
 use crate::active::Active;
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;
-use crate::float::Float;
 use crate::method;
 use crate::{LinkageState, Method};
 

--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -1,3 +1,5 @@
+use crate::Float;
+
 use crate::active::Active;
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,4 +1,4 @@
-use crate::float::Float;
+use crate::Float;
 
 // BREADCRUMBS: Look into moving `nearest` into this heap structure. It seems
 // like it might be doing too much at once, but things might actually become
@@ -169,6 +169,7 @@ mod tests {
     use crate::float::Float;
 
     use super::LinkageHeap;
+    use crate::Float;
 
     fn is_sorted_asc<T: Float>(xs: &[T]) -> bool {
         for win in xs.windows(2) {

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -166,10 +166,8 @@ impl<T: Float> LinkageHeap<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::float::Float;
-
-    use super::LinkageHeap;
     use crate::Float;
+    use super::LinkageHeap;
 
     fn is_sorted_asc<T: Float>(xs: &[T]) -> bool {
         for win in xs.windows(2) {

--- a/src/spanning.rs
+++ b/src/spanning.rs
@@ -1,3 +1,5 @@
+use crate::Float;
+
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;
 use crate::float::Float;

--- a/src/spanning.rs
+++ b/src/spanning.rs
@@ -1,8 +1,6 @@
 use crate::Float;
-
 use crate::condensed::CondensedMatrix;
 use crate::dendrogram::Dendrogram;
-use crate::float::Float;
 use crate::method;
 use crate::{LinkageState, Method};
 


### PR DESCRIPTION
Hi Andrew! 

First of all thanks a lot for developing this crate, I've been able to move some more of our data analysis pipeline to Rust thanks to it.

While I can understand why you want to get rid of the `num-traits` dependency in your context (at least, from what I got from the commit message of f19d626e4da6599063ccd52e8fd2c7f47cfbf86d), it's actually super practical to have it available because you can depend on custom float types, the most interesting one for me being [`f16`](https://docs.rs/half/2.2.1/half/struct.f16.html) from the `half` crate to work with a reduced memory footprint. The drop of `num-traits` support prevented me from updating to `v0.3`.

This PR keeps the best of both worlds by hiding the `num-traits` dependency behind a feature gate, which is disabled by default. Users like me who want to use the `Float` trait from `num-traits` can enable the feature, but by default `kodama` remains without dependency. 

